### PR TITLE
Fix AWS ALB 502 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const helmet = require("helmet");
 const cors = require("cors");
 const morgan = require("morgan");
@@ -73,8 +72,8 @@ app.disable("x-powered-by");
 if (process.env.NODE_ENV === "development") app.use(morgan("tiny")); // HTTP logging
 app.use(cors(corsOptions)); // middleware to enables cors
 app.use(helmet()); // middleware which adds http headers
-app.use(bodyParser.urlencoded({ extended: false, limit: "10mb" })); // middleware which parses body
-app.use(bodyParser.json({ limit: "10mb" })); // converts body to json
+app.use(express.urlencoded({ extended: false, limit: "10mb" })); // middleware which parses body
+app.use(express.json({ limit: "10mb" })); // converts body to json
 
 // bring all routes here
 const routes = require("./routes")(io);

--- a/index.js
+++ b/index.js
@@ -84,6 +84,6 @@ app.use("/", routes);
 const port = process.env.PORT || 5051;
 server.listen(port, () => log.info(`Server running on port: ${port}`));
 
-// for elb, https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/
+// Let AWS ALB drop connections (ref https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout)
 server.keepAliveTimeout = awsIdleTimeout + 5 * 1000;
 server.headersTimeout = awsIdleTimeout + 10 * 1000;

--- a/index.js
+++ b/index.js
@@ -2,39 +2,24 @@ const express = require("express");
 const helmet = require("helmet");
 const cors = require("cors");
 const morgan = require("morgan");
+const socketIO = require("socket.io");
 const socketRedis = require("socket.io-redis");
 const log = require("loglevel");
 const Sentry = require("@sentry/node");
 const Tracing = require("@sentry/tracing");
 
-// setup app
+// setup environment
+require("dotenv").config();
+
+const awsIdleTimeout = 60 * 1000; // AWS ALB idle timeout
+
+// setup Express app
 const app = express();
 const server = require("http").createServer(app);
 
-const awsIdleTimeout = 60 * 1000; // AWS ALB idle timeout
-const io = require("socket.io")(server, {
-  transports: ["websocket"],
-  cors: {
-    credentials: true,
-    origin: true,
-    methods: ["GET", "POST"],
-  },
-  // Let AWS ALB drop connections
-  connectTimeout: awsIdleTimeout + 5 * 1000,
-  pingTimeout: awsIdleTimeout + 5 * 1000,
-  upgradeTimeout: awsIdleTimeout + 5 * 1000,
-});
+// setup Sentry
 const redact = require("./utils/redactSentry");
 
-io.adapter(socketRedis({ host: process.env.REDIS_HOSTNAME, port: process.env.REDIS_PORT }));
-
-io.on("connection", () => {
-  log.debug("connected");
-});
-// Setup environment
-require("dotenv").config();
-
-// setup Sentry
 const isSentryConfigured = process.env.SENTRY_DSN && process.env.SENTRY_DSN.length > 0;
 if (isSentryConfigured) {
   Sentry.init({
@@ -76,13 +61,38 @@ app.use(express.urlencoded({ extended: false, limit: "10mb" })); // middleware w
 app.use(express.json({ limit: "10mb" })); // converts body to json
 
 // bring all routes here
-const routes = require("./routes")(io);
+const routes = require("./routes");
 
 app.use("/", routes);
 
+// setup socket.io
+const io = socketIO(server, {
+  transports: ["websocket"],
+  cors: {
+    credentials: true,
+    origin: true,
+    methods: ["GET", "POST"],
+  },
+  // let AWS ALB drop connections
+  connectTimeout: awsIdleTimeout + 5 * 1000,
+  pingTimeout: awsIdleTimeout + 5 * 1000,
+  upgradeTimeout: awsIdleTimeout + 5 * 1000,
+});
+
+io.adapter(socketRedis({ host: process.env.REDIS_HOSTNAME, port: process.env.REDIS_PORT }));
+io.on("connection", () => {
+  log.debug("connected");
+});
+
+// bring routes that require socket.io
+const emailAuthDataRoute = require("./routes/emailAuthData")(io);
+
+app.use("/auth", emailAuthDataRoute);
+
+// start server
 const port = process.env.PORT || 5051;
 server.listen(port, () => log.info(`Server running on port: ${port}`));
 
-// Let AWS ALB drop connections (ref https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout)
+// let AWS ALB drop connections (ref https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout)
 server.keepAliveTimeout = awsIdleTimeout + 5 * 1000;
 server.headersTimeout = awsIdleTimeout + 10 * 1000;

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -9,39 +9,43 @@ const { validateInput } = require("../validations");
 
 const elliptic = new EC("secp256k1");
 
-exports.validationMiddleware = (items, isBody = true) => (req, res, next) => {
-  try {
-    const { errors, isValid } = validateInput(isBody ? req.body : req.query, items);
-    if (!isValid) {
-      return res.status(400).json({ error: errors, success: false });
-    }
-    return next();
-  } catch (error) {
-    log.error("validationMiddleware internal error", error);
-    return res.status(500).json({ error: getError(error), success: false });
-  }
-};
-
-exports.validationLoopMiddleware = (items, key, isBody = true) => (req, res, next) => {
-  try {
-    const paramsObject = isBody ? req.body : req.query;
-    const mainParamToTest = paramsObject[key];
-    if (!Array.isArray(mainParamToTest)) {
-      return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
-    }
-    for (const [index, param] of mainParamToTest.entries()) {
-      const { errors, isValid } = validateInput(param, items);
+exports.validationMiddleware =
+  (items, isBody = true) =>
+  (req, res, next) => {
+    try {
+      const { errors, isValid } = validateInput(isBody ? req.body : req.query, items);
       if (!isValid) {
-        errors.index = index;
         return res.status(400).json({ error: errors, success: false });
       }
+      return next();
+    } catch (error) {
+      log.error("validationMiddleware internal error", error);
+      return res.status(500).json({ error: getError(error), success: false });
     }
-    return next();
-  } catch (error) {
-    log.error("validationLoopMiddleware internal error", error);
-    return res.status(500).json({ error: getError(error), success: false });
-  }
-};
+  };
+
+exports.validationLoopMiddleware =
+  (items, key, isBody = true) =>
+  (req, res, next) => {
+    try {
+      const paramsObject = isBody ? req.body : req.query;
+      const mainParamToTest = paramsObject[key];
+      if (!Array.isArray(mainParamToTest)) {
+        return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
+      }
+      for (const [index, param] of mainParamToTest.entries()) {
+        const { errors, isValid } = validateInput(param, items);
+        if (!isValid) {
+          errors.index = index;
+          return res.status(400).json({ error: errors, success: false });
+        }
+      }
+      return next();
+    } catch (error) {
+      log.error("validationLoopMiddleware internal error", error);
+      return res.status(500).json({ error: getError(error), success: false });
+    }
+  };
 
 exports.validateMetadataInput = async (req, res, next) => {
   const { set_data: setData = {} } = req.body;
@@ -58,28 +62,30 @@ exports.validateMetadataInput = async (req, res, next) => {
   return next();
 };
 
-exports.validateMetadataLoopInput = (key, isBody = true) => (req, res, next) => {
-  const paramsObject = isBody ? req.body : req.query;
-  const mainParamToTest = paramsObject[key];
-  // if (!Array.isArray(mainParamToTest)) {
-  //   return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
-  // }
-  for (const [index, param] of mainParamToTest.entries()) {
-    const { set_data: setData = {} } = param;
-    const { errors, isValid } = validateInput(setData, ["data", "timestamp"]);
-    if (!isValid) {
-      errors.index = index;
-      return res.status(400).json({ error: errors, success: false });
+exports.validateMetadataLoopInput =
+  (key, isBody = true) =>
+  (req, res, next) => {
+    const paramsObject = isBody ? req.body : req.query;
+    const mainParamToTest = paramsObject[key];
+    // if (!Array.isArray(mainParamToTest)) {
+    //   return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
+    // }
+    for (const [index, param] of mainParamToTest.entries()) {
+      const { set_data: setData = {} } = param;
+      const { errors, isValid } = validateInput(setData, ["data", "timestamp"]);
+      if (!isValid) {
+        errors.index = index;
+        return res.status(400).json({ error: errors, success: false });
+      }
+      const { timestamp } = setData;
+      const timeParsed = parseInt(timestamp, 16);
+      if (~~(Date.now() / 1000) - timeParsed > 60) {
+        errors.timestamp = "Message has been signed more than 60s ago";
+        return res.status(403).json({ error: errors, success: false });
+      }
     }
-    const { timestamp } = setData;
-    const timeParsed = parseInt(timestamp, 16);
-    if (~~(Date.now() / 1000) - timeParsed > 60) {
-      errors.timestamp = "Message has been signed more than 60s ago";
-      return res.status(403).json({ error: errors, success: false });
-    }
-  }
-  return next();
-};
+    return next();
+  };
 
 exports.validateSignature = async (req, res, next) => {
   try {
@@ -103,34 +109,36 @@ exports.validateSignature = async (req, res, next) => {
   }
 };
 
-exports.validateLoopSignature = (key, isBody = true) => (req, res, next) => {
-  const paramsObject = isBody ? req.body : req.query;
-  const mainParamToTest = paramsObject[key];
-  // if (!Array.isArray(mainParamToTest)) {
-  //   return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
-  // }
-  for (const [index, param] of mainParamToTest.entries()) {
-    try {
-      const { pub_key_X: pubKeyX, pub_key_Y: pubKeyY, signature, set_data: setData } = param;
-      const pubKey = elliptic.keyFromPublic({ x: pubKeyX, y: pubKeyY }, "hex");
-      const decodedSignature = Buffer.from(signature, "base64").toString("hex");
-      const ecSignature = {
-        r: Buffer.from(decodedSignature.substring(0, 64), "hex"),
-        s: Buffer.from(decodedSignature.substring(64, 128), "hex"),
-      };
-      const isValidSignature = elliptic.verify(keccak256(stringify(setData)), ecSignature, pubKey);
-      if (!isValidSignature) {
-        const errors = { index, signature: "Invalid signature" };
-        return res.status(403).json({ error: errors, success: false });
+exports.validateLoopSignature =
+  (key, isBody = true) =>
+  (req, res, next) => {
+    const paramsObject = isBody ? req.body : req.query;
+    const mainParamToTest = paramsObject[key];
+    // if (!Array.isArray(mainParamToTest)) {
+    //   return res.status(400).json({ error: { message: `${key} must be an array` }, success: false });
+    // }
+    for (const [index, param] of mainParamToTest.entries()) {
+      try {
+        const { pub_key_X: pubKeyX, pub_key_Y: pubKeyY, signature, set_data: setData } = param;
+        const pubKey = elliptic.keyFromPublic({ x: pubKeyX, y: pubKeyY }, "hex");
+        const decodedSignature = Buffer.from(signature, "base64").toString("hex");
+        const ecSignature = {
+          r: Buffer.from(decodedSignature.substring(0, 64), "hex"),
+          s: Buffer.from(decodedSignature.substring(64, 128), "hex"),
+        };
+        const isValidSignature = elliptic.verify(keccak256(stringify(setData)), ecSignature, pubKey);
+        if (!isValidSignature) {
+          const errors = { index, signature: "Invalid signature" };
+          return res.status(403).json({ error: errors, success: false });
+        }
+      } catch (error) {
+        error.index = index;
+        log.error("signature verification failed", error);
+        return res.status(500).json({ error: getError(error), success: false });
       }
-    } catch (error) {
-      error.index = index;
-      log.error("signature verification failed", error);
-      return res.status(500).json({ error: getError(error), success: false });
     }
-  }
-  return next();
-};
+    return next();
+  };
 
 exports.validateNamespace = (req, res, next) => {
   try {
@@ -143,20 +151,22 @@ exports.validateNamespace = (req, res, next) => {
   }
 };
 
-exports.validateNamespaceLoop = (key, isBody = true) => (req, res, next) => {
-  const paramsObject = isBody ? req.body : req.query;
-  const mainParamToTest = paramsObject[key];
-  for (const [index, param] of mainParamToTest.entries()) {
-    try {
-      const { namespace } = param;
-      param.tableName = getDBTableName(namespace);
-    } catch (error) {
-      log.error(index, error);
-      return res.status(500).json({ error: getError(error), success: false });
+exports.validateNamespaceLoop =
+  (key, isBody = true) =>
+  (req, res, next) => {
+    const paramsObject = isBody ? req.body : req.query;
+    const mainParamToTest = paramsObject[key];
+    for (const [index, param] of mainParamToTest.entries()) {
+      try {
+        const { namespace } = param;
+        param.tableName = getDBTableName(namespace);
+      } catch (error) {
+        log.error(index, error);
+        return res.status(500).json({ error: getError(error), success: false });
+      }
     }
-  }
-  return next();
-};
+    return next();
+  };
 
 exports.validateLockData = (req, res, next) => {
   try {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@sentry/node": "^6.4.1",
     "@sentry/tracing": "^6.4.1",
     "@toruslabs/loglevel-sentry": "^2.5.0",
-    "body-parser": "^1.19.0",
     "cids": "^1.1.6",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Torus metadata server",
   "main": "index.js",
   "scripts": {
-    "dev": "docker-compose -f docker-compose.dev.yml up --build -d",
+    "dev": "docker-compose -f docker-compose.dev.yml up --build",
     "down": "docker-compose -f docker-compose.dev.yml down",
     "serve": "npx nodemon index.js",
     "start": "node index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Torus metadata server",
   "main": "index.js",
   "scripts": {
-    "dev": "docker-compose -f docker-compose.dev.yml up --build",
+    "dev": "docker-compose -f docker-compose.dev.yml up --build -d",
     "down": "docker-compose -f docker-compose.dev.yml down",
     "serve": "npx nodemon index.js",
     "start": "node index.js",

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,15 +2,12 @@ const express = require("express");
 
 const router = express.Router();
 
-module.exports = (io) => {
-  const defaultRoute = require("./default");
-  const metadataRoute = require("./metadata");
-  const lockRoute = require("./lock");
-  const emailAuthDataRoute = require("./emailAuthData")(io);
+const defaultRoute = require("./default");
+const metadataRoute = require("./metadata");
+const lockRoute = require("./lock");
 
-  router.use("/", defaultRoute);
-  router.use("/", metadataRoute);
-  router.use("/", lockRoute);
-  router.use("/auth", emailAuthDataRoute);
-  return router;
-};
+router.use("/", defaultRoute);
+router.use("/", metadataRoute);
+router.use("/", lockRoute);
+
+module.exports = router;


### PR DESCRIPTION
Fix AWS ALB 502 errors by setting all connection timeout (HTTP keep-alive + WebSockets) bigger than AWS ALB idle timeout to let it decide when to drop connections.

Also move socket.io to after all HTTP Express middleware and routes setup are done, this might cause issues with body parsing (https://stackoverflow.com/questions/40059769/node-js-read-post-data-from-express-with-socket-io-and-http#comment93568867_40059877)